### PR TITLE
Fix sensitive data leaking to logs and harden runner/web-fetch safety

### DIFF
--- a/backend/infra/access_logger.go
+++ b/backend/infra/access_logger.go
@@ -1,0 +1,121 @@
+package infra
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/8treenet/freedom"
+	"github.com/8treenet/iris/v12/context"
+	"github.com/8treenet/freedom/middleware"
+	"github.com/kataras/golog"
+)
+
+// requestBodyMaxLen 单条请求体写入日志的最大长度，与 freedom 默认值保持一致。
+const requestBodyMaxLen = 512
+
+// maskPlaceholder 敏感字段脱敏后的占位值。
+const maskPlaceholder = "***"
+
+// sensitiveFieldKeys 需要脱敏的字段名（小写子串匹配）。
+var sensitiveFieldKeys = []string{"password", "passwd", "secret", "credential"}
+
+// NewAccessLogger 返回带敏感信息脱敏的请求日志中间件。
+//
+// 行为与 middleware.NewRequestLogger 一致：为每个条请求绑定独立的 trace logger，
+// 并在请求结束时输出 ACCESS 日志；区别在于写入日志前会对 JSON 请求体中的
+// 敏感字段（如 password）脱敏，避免明文密码落入日志。
+func NewAccessLogger(traceIDName string) func(context.Context) {
+	return func(ctx context.Context) {
+		startTime := time.Now()
+
+		var reqBody []byte
+		contentType := ctx.Request().Header.Get("Content-Type")
+		isJSON := strings.HasPrefix(strings.ToLower(contentType), "application/json")
+		if isJSON {
+			reqBody, _ = io.ReadAll(ctx.Request().Body)
+			ctx.Request().Body.Close()
+			ctx.Request().Body = io.NopCloser(bytes.NewBuffer(reqBody))
+		}
+
+		work := freedom.ToWorker(ctx)
+		freelog := middleware.NewLogger(traceIDName, work.Bus().Get(traceIDName))
+		for _, level := range []golog.Level{golog.DebugLevel, golog.WarnLevel, golog.ErrorLevel, golog.FatalLevel} {
+			freelog.SetCallerLevel(level)
+		}
+		work.SetLogger(freelog)
+
+		rawQuery := ctx.Request().URL.Query()
+		ctx.Next()
+
+		fieldsMessage := golog.Fields{}
+		fieldsMessage["status"] = strconv.Itoa(ctx.GetStatusCode())
+		fieldsMessage["latency"] = time.Since(startTime).String()
+		fieldsMessage["method"] = ctx.Method()
+		fieldsMessage["path"] = ctx.Path()
+		if len(rawQuery) > 0 {
+			fieldsMessage["query"] = rawQuery.Encode()
+		}
+		if traceInfo := work.Bus().Get(traceIDName); traceInfo != "" {
+			fieldsMessage[traceIDName] = traceInfo
+		}
+		if len(reqBody) > 0 {
+			masked := maskSensitiveJSON(reqBody)
+			masked = masked[:min(len(masked), requestBodyMaxLen)]
+			if masked != "" {
+				fieldsMessage["request"] = masked
+			}
+		}
+		ctx.Application().Logger().Info("[ACCESS]", fieldsMessage)
+	}
+}
+
+// maskSensitiveJSON 对 JSON 请求体中的敏感字段值做脱敏。
+// 非法 JSON 返回占位文本，避免意外泄露；空内容返回空字符串。
+func maskSensitiveJSON(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var parsed interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "[unparseable json body omitted]"
+	}
+	maskJSONValue(parsed)
+	out, err := json.Marshal(parsed)
+	if err != nil {
+		return "[unparseable json body omitted]"
+	}
+	return string(out)
+}
+
+// maskJSONValue 递归遍历已解析的 JSON 值，将命中敏感字段名的值替换为占位符。
+func maskJSONValue(v interface{}) {
+	switch val := v.(type) {
+	case map[string]interface{}:
+		for k, child := range val {
+			if isSensitiveField(k) {
+				val[k] = maskPlaceholder
+				continue
+			}
+			maskJSONValue(child)
+		}
+	case []interface{}:
+		for _, child := range val {
+			maskJSONValue(child)
+		}
+	}
+}
+
+// isSensitiveField 判断字段名是否命中敏感字段（大小写不敏感的子串匹配）。
+func isSensitiveField(key string) bool {
+	lower := strings.ToLower(key)
+	for _, sensitive := range sensitiveFieldKeys {
+		if strings.Contains(lower, sensitive) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/infra/access_logger_test.go
+++ b/backend/infra/access_logger_test.go
@@ -1,0 +1,93 @@
+package infra
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestMaskSensitiveJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "mask login password",
+			input: `{"username":"admin","password":"secret123"}`,
+			want:  `{"username":"admin","password":"***"}`,
+		},
+		{
+			name:  "mask current and new password",
+			input: `{"currentPassword":"a","newPassword":"b"}`,
+			want:  `{"currentPassword":"***","newPassword":"***"}`,
+		},
+		{
+			name:  "mask nested password",
+			input: `{"user":{"name":"u","password":"p"},"token":"x"}`,
+			want:  `{"user":{"name":"u","password":"***"},"token":"x"}`,
+		},
+		{
+			name:  "mask password in array",
+			input: `{"list":[{"password":"p"},{"name":"n"}]}`,
+			want:  `{"list":[{"password":"***"},{"name":"n"}]}`,
+		},
+		{
+			name:  "keep normal body",
+			input: `{"content":"hello","sessionId":"abc"}`,
+			want:  `{"content":"hello","sessionId":"abc"}`,
+		},
+		{
+			name:  "unparseable json",
+			input: `{"password": "broken`,
+			want:  "[unparseable json body omitted]",
+		},
+		{
+			name:  "empty body",
+			input: ``,
+			want:  ``,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := maskSensitiveJSON([]byte(tc.input))
+			if tc.want == "" {
+				if got != tc.want {
+					t.Errorf("maskSensitiveJSON(%q) = %q, want %q", tc.input, got, tc.want)
+				}
+				return
+			}
+			// JSON 对象 key 顺序不保证，做结构化比较
+			if tc.want != "[unparseable json body omitted]" {
+				var gotVal, wantVal interface{}
+				if err := json.Unmarshal([]byte(got), &gotVal); err != nil {
+					t.Fatalf("output is not valid json: %s", got)
+				}
+				if err := json.Unmarshal([]byte(tc.want), &wantVal); err != nil {
+					t.Fatalf("want is not valid json: %s", tc.want)
+				}
+				if !reflect.DeepEqual(gotVal, wantVal) {
+					t.Errorf("maskSensitiveJSON(%q) = %q, want %q", tc.input, got, tc.want)
+				}
+				return
+			}
+			if got != tc.want {
+				t.Errorf("maskSensitiveJSON(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsSensitiveField(t *testing.T) {
+	for _, key := range []string{"password", "Password", "currentPassword", "newPassword", "user_passwd", "clientSecret"} {
+		if !isSensitiveField(key) {
+			t.Errorf("isSensitiveField(%q) = false, want true", key)
+		}
+	}
+	for _, key := range []string{"username", "content", "sessionId"} {
+		if isSensitiveField(key) {
+			t.Errorf("isSensitiveField(%q) = true, want false", key)
+		}
+	}
+}

--- a/backend/service/chat.go
+++ b/backend/service/chat.go
@@ -217,12 +217,17 @@ func (service *ChatService) StartChat(
 		service.DailyStatsRepo.AddToolDailyStats(userId, "skill", name)
 	})
 	mainAgent.SetSkillAccessor(simpleSkillFilter)
-	agent.RegisterRunnerHold(session.SessionId)
+	// CAS 抢占会话构建锁：同会话已有构建中的/活跃的 Runner 时直接拒绝，
+	// 防止并发 StartChat 导致双 Runner 交错写消息。
+	if !agent.HoldRunner(session.SessionId) {
+		return nil, errs.ErrChatSessionActive
+	}
 	service.Worker.DeferRecycle()
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
 				freedom.Logger().Errorf("StartChat panic: %v\n%s", r, debug.Stack())
+				agent.ClearRunnerHold(session.SessionId)
 				if spLocked {
 					service.SharedProjectRepo.UnlockTeamProject(spId)
 				}

--- a/core/agent/main_runner.go
+++ b/core/agent/main_runner.go
@@ -47,6 +47,13 @@ type collectedMsg struct {
 var activeRunners sync.Map
 var runnerHold sync.Map
 
+// HoldRunner 以 CAS 语义注册构建 hold：如果尚无 hold 则注册并返回 true；
+// 已存在（同会话正在构建）则返回 false。用于防止同一会话并发启动多个 Runner。
+func HoldRunner(sessionId string) bool {
+	_, loaded := runnerHold.LoadOrStore(sessionId, true)
+	return !loaded
+}
+
 func RegisterRunnerHold(sessionId string) {
 	runnerHold.Store(sessionId, true)
 }
@@ -96,6 +103,8 @@ type MainRunner struct {
 	runner               *adk.Runner
 	history              []adk.Message
 	sseChan              chan *SSEEvent
+	sseMu                sync.Mutex // 保护 sseChan 的生命周期，防止 send on closed channel
+	sseClosed            bool
 	saveReplyContent     string
 	saveReasoningContent string
 	// 0未开始拉取，1开始拉取
@@ -210,11 +219,32 @@ func (runner *MainRunner) dispatchSSE(event *SSEEvent) {
 		return
 	}
 
+	runner.sendSSE(event)
+}
+
+// sendSSE 将事件写入 SSE 通道。与 closeSSEChan 互斥，杜绝 send on closed channel。
+func (runner *MainRunner) sendSSE(event *SSEEvent) {
+	runner.sseMu.Lock()
+	defer runner.sseMu.Unlock()
+	if runner.sseClosed {
+		return
+	}
 	select {
 	case runner.sseChan <- event:
 	case <-time.After(500 * time.Millisecond):
 		freedom.Logger().Debug("send sse event timeout")
 	}
+}
+
+// closeSSEChan 关闭 SSE 通道，可安全重复调用。
+func (runner *MainRunner) closeSSEChan() {
+	runner.sseMu.Lock()
+	defer runner.sseMu.Unlock()
+	if runner.sseClosed {
+		return
+	}
+	runner.sseClosed = true
+	close(runner.sseChan)
 }
 
 func (runner *MainRunner) sendSSEToolEvent(name, arguments string) (eventTool string) {
@@ -310,6 +340,9 @@ func (runner *MainRunner) Query(runctx context.Context, content string) (err err
 	runner.stop = false
 	runner.fetchStatus = 0
 	runner.Mutex.Unlock()
+	runner.sseMu.Lock()
+	runner.sseClosed = false
+	runner.sseMu.Unlock()
 
 	runner.history, err = runner.getHistory()
 	if err != nil {
@@ -337,7 +370,7 @@ func (runner *MainRunner) Query(runctx context.Context, content string) (err err
 			}
 			runner.Terminat()
 			runner.sendSSEEvent(&SSEEvent{Type: SSEEventTypeEnd})
-			close(runner.sseChan)
+			runner.closeSSEChan()
 			DeleteRunner(runner.mainAgent.param.SessionId())
 			runner.mainAgent.msgRepo.UpdateSessionStatus(runner.mainAgent.param.SessionId(), 0)
 

--- a/core/agent/runner_sse_test.go
+++ b/core/agent/runner_sse_test.go
@@ -1,0 +1,39 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestHoldRunnerCAS(t *testing.T) {
+	if ok := HoldRunner("cas-session-1"); !ok {
+		t.Errorf("first HoldRunner should succeed")
+	}
+	if ok := HoldRunner("cas-session-1"); ok {
+		t.Errorf("second HoldRunner for same session should fail")
+	}
+	ClearRunnerHold("cas-session-1")
+	if ok := HoldRunner("cas-session-1"); !ok {
+		t.Errorf("HoldRunner should succeed after ClearRunnerHold")
+	}
+	ClearRunnerHold("cas-session-1")
+}
+
+func TestSendSSEConcurrentWithClose(t *testing.T) {
+	runner := &MainRunner{}
+	runner.sseChan = make(chan *SSEEvent, 1)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runner.sendSSE(&SSEEvent{Type: SSEEventTypeContent})
+		}()
+	}
+	runner.closeSSEChan()
+	wg.Wait()
+
+	// 重复 close 不应 panic
+	runner.closeSSEChan()
+}

--- a/core/tools/ssrf_guard.go
+++ b/core/tools/ssrf_guard.go
@@ -1,0 +1,65 @@
+package tools
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// validatePublicHTTPURL 校验外部抓取 URL，防止 SSRF：
+//   - 仅允许 http/https 协议（阻断 file://、gopher:// 等）
+//   - 目标地址（IP 直连或域名解析结果）不得为回环、私网、链路本地等内网地址
+//
+// 注意：域名场景下在校验与实际请求之间存在 DNS 重绑定（rebinding）的 TOCTOU 窗口，
+// 按当前架构已能拦截绝大部分误用；彻底解决需要在传输层固定解析后的 IP。
+func validatePublicHTTPURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("scheme %q is not allowed, only http and https are supported", u.Scheme)
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("url has no host")
+	}
+
+	// host 为 IP 字面量，直接校验
+	if ip := net.ParseIP(host); ip != nil {
+		if !isPublicIP(ip) {
+			return fmt.Errorf("access to private or reserved address is not allowed: %s", host)
+		}
+		return nil
+	}
+
+	// 域名场景：解析后对所有结果逐一校验
+	addrs, err := net.LookupHost(host)
+	if err != nil {
+		return fmt.Errorf("failed to resolve host %q: %w", host, err)
+	}
+	for _, addr := range addrs {
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			continue
+		}
+		if !isPublicIP(ip) {
+			return fmt.Errorf("host %q resolves to private or reserved address: %s", host, addr)
+		}
+	}
+	return nil
+}
+
+// isPublicIP 判断 IP 是否为可对外访问的公网地址。
+func isPublicIP(ip net.IP) bool {
+	return !(ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified())
+}

--- a/core/tools/ssrf_guard_test.go
+++ b/core/tools/ssrf_guard_test.go
@@ -1,0 +1,44 @@
+package tools
+
+import "testing"
+
+func TestValidatePublicHTTPURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"https to public ip", "https://1.1.1.1/index.html", false},
+		{"http to public ip", "http://8.8.8.8:8080/path?q=1", false},
+		{"file scheme", "file:///etc/passwd", true},
+		{"ftp scheme", "ftp://example.com/file", true},
+		{"gopher scheme", "gopher://127.0.0.1:6379/_info", true},
+		{"empty host", "http:///path", true},
+		{"missing scheme", "/etc/passwd", true},
+		{"loopback v4", "http://127.0.0.1/admin", true},
+		{"loopback alt v4", "http://127.1.0.1/", true},
+		{"private v4 10/8", "http://10.0.0.1/", true},
+		{"private v4 172.16/12", "http://172.16.0.1/", true},
+		{"private v4 192.168/16", "http://192.168.1.1/", true},
+		{"link local", "http://169.254.169.254/latest/meta-data", true},
+		{"loopback v6", "http://[::1]/", true},
+		{"private v6 ula", "http://[fd00::1]/", true},
+		{"link local v6", "http://[fe80::1]/", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePublicHTTPURL(tc.url)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validatePublicHTTPURL(%q) error = %v, wantErr %v", tc.url, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidatePublicHTTPURLResolvesHost(t *testing.T) {
+	// localhost 在标准环境下解析为 127.0.0.1，应被拒绝
+	if err := validatePublicHTTPURL("http://localhost:8000/api"); err == nil {
+		t.Errorf("validatePublicHTTPURL(localhost) should fail, got nil")
+	}
+}

--- a/core/tools/webfetch.go
+++ b/core/tools/webfetch.go
@@ -63,6 +63,11 @@ func (w *WebFetch) Invoke(ctx context.Context, req *WebFetchRequest) (*WebFetchR
 		return nil, fmt.Errorf("URL不能为空")
 	}
 
+	// SSRF 防护：仅允许公网 http/https 目标
+	if err := validatePublicHTTPURL(req.URL); err != nil {
+		return nil, fmt.Errorf("URL校验失败: %w", err)
+	}
+
 	html, resp := requests.NewHTTPRequest(req.URL).Get().SetClient(webFetchClient).ToString()
 	if resp != nil && resp.Error != nil {
 		return nil, fmt.Errorf("请求网页失败: %w", resp.Error)

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func installMiddleware(app freedom.Application) {
 	app.InstallMiddleware(middleware.NewRecover())
 	app.InstallMiddleware(middleware.NewTrace("x-request-id"))
 	//One Loger per request New.
-	app.InstallMiddleware(middleware.NewRequestLogger("x-request-id"))
+	app.InstallMiddleware(infra.NewAccessLogger("x-request-id"))
 	//The middleware output of the log line.
 	app.Logger().Handle(middleware.DefaultLogRowHandle)
 


### PR DESCRIPTION
## Summary

This PR fixes one security bug found during a security review of the codebase and three reliability issues.

### 1. Mask sensitive fields in access log request bodies

The ACCESS log middleware (`freedom/middleware.NewRequestLogger`) dumps the raw request body of every request, so plaintext passwords end up in the logs:

```
[ACCESS]  method:POST  path:/api/user/login  request:{"username":"administrator","password":"admin12345"}  status:200
```

This replaces it with a dedicated access logger in `backend/infra` that keeps the same log format but masks values of sensitive keys (password/passwd/secret/credential, matched case-insensitively, recursively) before logging. Non-JSON bodies are not logged raw.

### 2. Add SSRF protection to the web fetch tool

`goraven_web_fetch` accepted arbitrary URLs with no scheme or host validation. An agent could use it to reach loopback/private/link-local endpoints (e.g. cloud metadata at 169.254.169.254). The tool now only accepts `http`/`https` and rejects hosts that resolve to private, loopback, or link-local addresses.

### 3. Guard SSE channel close against concurrent sends

`MainRunner.Query` closes `runner.sseChan` in its defer while other goroutines (model-retry callback, heartbeat, sub-agent events) may still be inside `dispatchSSE`, which can panic with *send on closed channel*. Channel lifecycle is now guarded by a dedicated mutex (`sseMu` + `sseClosed`), and `closeSSEChan` is idempotent.

### 4. Reject concurrent StartChat for the same session

The session-active check in `ChatService.StartChat` races against runner registration: two concurrent requests could both pass and start two runners for one session, interleaving message persistence and letting the first completion delete the second runner's registration. The hold is now taken with `LoadOrStore` (CAS semantics) via `agent.HoldRunner`, and the panic-recovery path also releases the hold.

## Testing

- [x] `go build ./...` clean; `go vet` clean
- [x] New unit tests: access-log masking, SSRF URL validation (scheme + private ranges + v6), CAS hold, concurrent send/close race (passes under `-race`)
- [x] Full test suite: no new failures vs master (the 18 failures in `backend/controller/test` also fail on master — environment-dependent, unrelated)
- [x] Deployed the rebuilt binary in the Docker runtime and verified live: login flow works, logs now show `"password":"***"`, non-sensitive JSON bodies still logged, GET/dashboard/session APIs unaffected

## Notes

- Two further hardening items are intentionally not included here to keep this PR reviewable: migrating password storage from unsalted MD5 to bcrypt (needs a migration path for existing installs) and the sandbox symlink-escape / regex-bypass issues in the local sandbox (best addressed by completing the docker sandbox backend).

—
🤖 Generated with [opencode](https://opencode.ai)