### PR TITLE
Migrate passwords to bcrypt and add sandbox symlink containment

### DIFF
--- a/backend/controller/hfs.go
+++ b/backend/controller/hfs.go
@@ -134,8 +134,33 @@ func (controller *HFSController) AbsoluteDownload(p string) {
 		return
 	}
 	cleanAbs := filepath.Clean(absPath)
+	// 兼容相对路径配置：统一转为绝对路径后再比较
 	userSpaceRoot := filepath.Clean(config.Get().Paths.UserSpace)
+	if absRoot, absErr := filepath.Abs(userSpaceRoot); absErr == nil {
+		userSpaceRoot = absRoot
+	}
 	if !strings.HasPrefix(cleanAbs, userSpaceRoot+string(filepath.Separator)) {
+		controller.Worker.IrisContext().StatusCode(403)
+		controller.Worker.IrisContext().WriteString("path is outside user space")
+		return
+	}
+	// 符号链接逃逸防护：解析后的真实路径必须仍位于用户空间内
+	resolvedAbs, resolveErr := filepath.EvalSymlinks(cleanAbs)
+	if resolveErr != nil {
+		if os.IsNotExist(resolveErr) {
+			controller.Worker.IrisContext().StatusCode(404)
+			controller.Worker.IrisContext().WriteString("File not found")
+			return
+		}
+		controller.Worker.IrisContext().StatusCode(500)
+		controller.Worker.IrisContext().WriteString(resolveErr.Error())
+		return
+	}
+	resolvedRoot, rootErr := filepath.EvalSymlinks(userSpaceRoot)
+	if rootErr != nil {
+		resolvedRoot = userSpaceRoot
+	}
+	if !strings.HasPrefix(resolvedAbs, resolvedRoot+string(filepath.Separator)) && resolvedAbs != resolvedRoot {
 		controller.Worker.IrisContext().StatusCode(403)
 		controller.Worker.IrisContext().WriteString("path is outside user space")
 		return

--- a/backend/po/user.go
+++ b/backend/po/user.go
@@ -30,7 +30,7 @@ const (
 type User struct {
 	UserId     string    `gorm:"primaryKey;column:user_id;type:varchar(64)"`            // 主键唯一ID，与 session.userId 保持一致
 	Username   string    `gorm:"uniqueIndex;column:username;type:varchar(64);not null"` // 登录账号，全局唯一
-	Password   string    `gorm:"column:password;type:varchar(256);not null"`            // 密码（存储 MD5 哈希值，由后端统一哈希，禁止明文）
+	Password   string    `gorm:"column:password;type:varchar(256);not null"`            // 密码（存储 bcrypt 哈希值，由后端统一哈希，禁止明文）
 	Email      string    `gorm:"column:email;type:varchar(128)"`                        // 邮箱
 	Role       uint8     `gorm:"column:role;default:0;not null"`                        // 角色：0普通用户 1管理员
 	SuperAdmin uint8     `gorm:"column:super_admin;default:0;not null"`                 // 超级管理员：0否 1是

--- a/backend/service/install.go
+++ b/backend/service/install.go
@@ -125,11 +125,15 @@ func (service *InstallService) Init(req *vo.InstallInitReq) (*vo.InstallInitRsp,
 
 	var userId string
 	var existingUser po.User
+	hashedPassword, err := util.HashPassword(req.Password)
+	if err != nil {
+		return nil, err
+	}
 	err = db.Where("super_admin = ?", 1).First(&existingUser).Error
 	if err == nil {
 		// 超管已存在，更新除 userId 外的所有字段
 		existingUser.Username = req.Username
-		existingUser.Password = util.MD5(req.Password) // 前端传明文，后端做 MD5
+		existingUser.Password = hashedPassword
 		existingUser.Email = req.Email
 		existingUser.Role = 1
 		existingUser.SuperAdmin = 1
@@ -144,7 +148,7 @@ func (service *InstallService) Init(req *vo.InstallInitReq) (*vo.InstallInitRsp,
 		user := &po.User{
 			UserId:     userId,
 			Username:   req.Username,
-			Password:   util.MD5(req.Password), // 前端传明文，后端做 MD5
+			Password:   hashedPassword,
 			Email:      req.Email,
 			Role:       1,
 			SuperAdmin: 1,

--- a/backend/service/user.go
+++ b/backend/service/user.go
@@ -49,9 +49,16 @@ func (service *UserService) Login(req *vo.UserLoginReq) (*vo.UserLoginRsp, error
 		return nil, errs.ErrInvalidCredentials
 	}
 
-	if user.Password != util.MD5(req.Password) {
+	ok, legacy := util.VerifyPassword(user.Password, req.Password)
+	if !ok {
 		service.UserRepo.RecordLoginFailure()
 		return nil, errs.ErrInvalidCredentials
+	}
+	if legacy {
+		// 旧版无盐 MD5 哈希，登录成功后透明升级为 bcrypt
+		if hashed, err := util.HashPassword(req.Password); err == nil {
+			_ = service.UserRepo.UpdatePassword(user.UserId, hashed)
+		}
 	}
 
 	if user.Status != po.UserStatusEnabled {
@@ -204,10 +211,14 @@ func (service *UserService) AdminCreateUser(req *vo.AdminCreateUserReq) error {
 		return errs.ErrUsernameAlreadyExists
 	}
 
+	hashedPassword, err := util.HashPassword(req.Password)
+	if err != nil {
+		return err
+	}
 	user := &po.User{
 		UserId:   util.UUID(),
 		Username: req.Username,
-		Password: util.MD5(req.Password),
+		Password: hashedPassword,
 		Nickname: req.Nickname,
 		Role:     req.Role,
 		Status:   po.UserStatusEnabled,
@@ -269,7 +280,11 @@ func (service *UserService) AdminResetPassword(userId string, req *vo.AdminReset
 		return errs.ErrCannotResetSuperAdminPassword
 	}
 
-	if err := service.UserRepo.UpdatePassword(userId, util.MD5(req.Password)); err != nil {
+	hashedPassword, err := util.HashPassword(req.Password)
+	if err != nil {
+		return err
+	}
+	if err := service.UserRepo.UpdatePassword(userId, hashedPassword); err != nil {
 		return err
 	}
 	service.UserRepo.Auth.DeleteUserTokens(userId, "")
@@ -339,7 +354,8 @@ func (service *UserService) ChangePassword(req *vo.UserPasswordReq) error {
 		return errs.ErrInvalidCredentials
 	}
 
-	if user.Password != util.MD5(req.CurrentPassword) {
+	ok, _ := util.VerifyPassword(user.Password, req.CurrentPassword)
+	if !ok {
 		return errs.ErrPasswordIncorrect
 	}
 
@@ -347,7 +363,11 @@ func (service *UserService) ChangePassword(req *vo.UserPasswordReq) error {
 		return errs.ErrPasswordSameAsCurrent
 	}
 
-	if err := service.UserRepo.UpdatePassword(userId, util.MD5(req.NewPassword)); err != nil {
+	hashedPassword, err := util.HashPassword(req.NewPassword)
+	if err != nil {
+		return err
+	}
+	if err := service.UserRepo.UpdatePassword(userId, hashedPassword); err != nil {
 		return err
 	}
 

--- a/backend/vo/user.go
+++ b/backend/vo/user.go
@@ -3,7 +3,7 @@ package vo
 import "time"
 
 // UserLoginReq 用户登录请求
-// 前端传明文密码，后端统一做 MD5 哈希
+// 前端传明文密码，后端统一做 bcrypt 哈希
 type UserLoginReq struct {
 	Username      string `json:"username" validate:"required"` // 用户名
 	Password      string `json:"password" validate:"required"` // 明文密码
@@ -66,7 +66,7 @@ type AdminUserItem struct {
 // AdminCreateUserReq 管理员创建用户请求
 type AdminCreateUserReq struct {
 	Username string `json:"username" validate:"required,min=8,max=16"` // 用户名 8-16 字符
-	Password string `json:"password" validate:"required"`              // 明文密码（后端做 MD5 哈希）
+	Password string `json:"password" validate:"required"`              // 明文密码（后端做 bcrypt 哈希）
 	Nickname string `json:"nickname"`                                   // 昵称
 	Role     uint8  `json:"role"`                                       // 角色 0普通用户 1管理员
 }
@@ -103,7 +103,7 @@ type AdminUserDetailRsp struct {
 
 // AdminResetPasswordReq 管理员重置密码请求
 type AdminResetPasswordReq struct {
-	Password string `json:"password" validate:"required"` // 明文新密码（后端做 MD5 哈希）
+	Password string `json:"password" validate:"required"` // 明文新密码（后端做 bcrypt 哈希）
 }
 
 // UserProfileReq 个人资料修改请求
@@ -115,7 +115,7 @@ type UserProfileReq struct {
 }
 
 // UserPasswordReq 用户修改密码请求
-// 前端传明文密码，后端统一做 MD5 哈希
+// 前端传明文密码，后端统一做 bcrypt 哈希
 type UserPasswordReq struct {
 	CurrentPassword string `json:"currentPassword" validate:"required"` // 当前明文密码
 	NewPassword     string `json:"newPassword" validate:"required"`     // 新明文密码

--- a/core/sandbox/local/backend_guard.go
+++ b/core/sandbox/local/backend_guard.go
@@ -1,0 +1,97 @@
+package local
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/cloudwego/eino/adk/filesystem"
+)
+
+// guardedBackend 在 eino 本地文件系统后端之上增加工作区路径校验。
+//
+// eino-ext 的 local 后端没有任何根目录约束（默认根为 "/"），Agent 的
+// read/write/edit/grep/glob/ls 工具可直接访问宿主文件系统。本装饰器
+// 在委托前把所有路径参数约束到用户工作区内（含符号链接逃逸检查），
+// 相对路径按工作区根解析。
+type guardedBackend struct {
+	inner     filesystem.Backend
+	workspace string
+}
+
+var _ filesystem.Backend = (*guardedBackend)(nil)
+
+// newGuardedBackend 创建带工作区校验的文件系统后端。
+func newGuardedBackend(inner filesystem.Backend, workspace string) *guardedBackend {
+	return &guardedBackend{inner: inner, workspace: workspace}
+}
+
+// validate 将路径约束到工作区内，返回清洗后的绝对路径。
+func (g *guardedBackend) validate(p string) (string, error) {
+	if p == "" {
+		return g.workspace, nil
+	}
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(g.workspace, p)
+	}
+	cleanPath := filepath.Clean(p)
+	if err := checkContainment(cleanPath, []string{g.workspace}); err != nil {
+		return "", fmt.Errorf("path is outside the agent workspace: %s", p)
+	}
+	return cleanPath, nil
+}
+
+func (g *guardedBackend) LsInfo(ctx context.Context, req *filesystem.LsInfoRequest) ([]filesystem.FileInfo, error) {
+	validated, err := g.validate(req.Path)
+	if err != nil {
+		return nil, err
+	}
+	req.Path = validated
+	return g.inner.LsInfo(ctx, req)
+}
+
+func (g *guardedBackend) Read(ctx context.Context, req *filesystem.ReadRequest) (*filesystem.FileContent, error) {
+	validated, err := g.validate(req.FilePath)
+	if err != nil {
+		return nil, err
+	}
+	req.FilePath = validated
+	return g.inner.Read(ctx, req)
+}
+
+func (g *guardedBackend) GrepRaw(ctx context.Context, req *filesystem.GrepRequest) ([]filesystem.GrepMatch, error) {
+	// Path 为空时 backend 默认从进程根开始搜索，强制收敛到工作区
+	validated, err := g.validate(req.Path)
+	if err != nil {
+		return nil, err
+	}
+	req.Path = validated
+	return g.inner.GrepRaw(ctx, req)
+}
+
+func (g *guardedBackend) GlobInfo(ctx context.Context, req *filesystem.GlobInfoRequest) ([]filesystem.FileInfo, error) {
+	validated, err := g.validate(req.Path)
+	if err != nil {
+		return nil, err
+	}
+	req.Path = validated
+	return g.inner.GlobInfo(ctx, req)
+}
+
+func (g *guardedBackend) Write(ctx context.Context, req *filesystem.WriteRequest) error {
+	validated, err := g.validate(req.FilePath)
+	if err != nil {
+		return err
+	}
+	req.FilePath = validated
+	return g.inner.Write(ctx, req)
+}
+
+func (g *guardedBackend) Edit(ctx context.Context, req *filesystem.EditRequest) error {
+	validated, err := g.validate(req.FilePath)
+	if err != nil {
+		return err
+	}
+	req.FilePath = validated
+	return g.inner.Edit(ctx, req)
+}

--- a/core/sandbox/local/file_manager.go
+++ b/core/sandbox/local/file_manager.go
@@ -33,7 +33,8 @@ func (m *LocalFileManager) resolvePath(relPath string) (string, error) {
 	absPath := filepath.Join(cleanWorkspace, relPath)
 	cleanPath := filepath.Clean(absPath)
 
-	if !strings.HasPrefix(cleanPath, cleanWorkspace+string(filepath.Separator)) && cleanPath != cleanWorkspace {
+	// 字符串前缀 + 符号链接解析双重校验，防止通过符号链接逃逸工作区
+	if err := checkContainment(cleanPath, []string{cleanWorkspace}); err != nil {
 		return "", fmt.Errorf("path escapes workspace: %s", relPath)
 	}
 	return cleanPath, nil

--- a/core/sandbox/local/local.go
+++ b/core/sandbox/local/local.go
@@ -34,9 +34,13 @@ func NewLocalSandbox(userName string) *LocalSandbox {
 	}
 }
 
-// NewBackend 创建本地文件系统后端
+// NewBackend 创建本地文件系统后端，包装为带工作区路径校验的受保护后端
 func (s *LocalSandbox) NewBackend() (types.Backend, error) {
-	return local.NewBackend(context.Background(), &local.Config{})
+	inner, err := local.NewBackend(context.Background(), &local.Config{})
+	if err != nil {
+		return nil, err
+	}
+	return newGuardedBackend(inner, s.Workspace), nil
 }
 
 // StreamingShell 创建本地Shell
@@ -307,17 +311,15 @@ func (s *LocalSandbox) validateFilePath(filePath string) (string, error) {
 	}
 
 	cleanPath := filepath.Clean(filePath)
-	cleanWorkspace := filepath.Clean(s.GetWorkspace())
-	if strings.HasPrefix(cleanPath, cleanWorkspace+string(filepath.Separator)) || cleanPath == cleanWorkspace {
-		return cleanPath, nil
-	}
+	roots := []string{s.GetWorkspace()}
 	if s.extraWorkspace != "" {
-		cleanShared := filepath.Clean(s.extraWorkspace)
-		if strings.HasPrefix(cleanPath, cleanShared+string(filepath.Separator)) || cleanPath == cleanShared {
-			return cleanPath, nil
-		}
+		roots = append(roots, s.extraWorkspace)
 	}
-	return "", fmt.Errorf("path is outside user workspace: %s", filePath)
+	// 字符串前缀 + 符号链接解析双重校验，防止通过符号链接逃逸工作区
+	if err := checkContainment(cleanPath, roots); err != nil {
+		return "", err
+	}
+	return cleanPath, nil
 }
 
 func (s *LocalSandbox) NewStdioMCPClient(command string, env []string, args ...string) (*mcpclient.Client, error) {

--- a/core/sandbox/local/symlink_guard.go
+++ b/core/sandbox/local/symlink_guard.go
@@ -1,0 +1,83 @@
+package local
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// resolveSymlinkPath 解析路径中的符号链接，返回真实路径。
+//
+// 路径本身不存在时，解析其最深的存在着的父目录后拼回剩余部分，
+// 以便对"将要写入的文件"也能提前发现逃逸链接。
+func resolveSymlinkPath(p string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(p)
+	if err == nil {
+		return resolved, nil
+	}
+
+	// 路径不存在：向上找到最深的存在着的祖先
+	dir := filepath.Dir(p)
+	rest := filepath.Base(p)
+	for {
+		if dir == string(filepath.Separator) || dir == "." {
+			break
+		}
+		if _, statErr := os.Lstat(dir); statErr == nil {
+			break
+		}
+		rest = filepath.Join(filepath.Base(dir), rest)
+		dir = filepath.Dir(dir)
+	}
+
+	resolvedDir, evalErr := filepath.EvalSymlinks(dir)
+	if evalErr != nil {
+		return "", err
+	}
+	return filepath.Join(resolvedDir, rest), nil
+}
+
+// pathWithin 判断 path 是否位于 base 目录内（或等于 base）。
+// 仅做字符串比较，调用方需保证两者都已 Clean。
+func pathWithin(path, base string) bool {
+	if path == base {
+		return true
+	}
+	return strings.HasPrefix(path, base+string(filepath.Separator))
+}
+
+// checkContainment 校验路径（字符串前缀 + 符号链接解析后）都落在允许的根目录内。
+// roots 为允许的根目录列表；返回 nil 表示安全，否则返回错误。
+func checkContainment(cleanPath string, roots []string) error {
+	resolvedRoots := make([]string, 0, len(roots))
+	allowed := false
+	for _, root := range roots {
+		if root == "" {
+			continue
+		}
+		cleanRoot := filepath.Clean(root)
+		resolvedRoots = append(resolvedRoots, cleanRoot)
+		if resolvedRoot, err := filepath.EvalSymlinks(cleanRoot); err == nil {
+			resolvedRoots = append(resolvedRoots, resolvedRoot)
+		}
+		if pathWithin(cleanPath, cleanRoot) {
+			allowed = true
+		}
+	}
+	if !allowed {
+		return fmt.Errorf("path is outside allowed roots: %s", cleanPath)
+	}
+
+	// 符号链接逃逸防护：解析后的真实路径必须仍位于允许的根目录内
+	resolved, err := resolveSymlinkPath(cleanPath)
+	if err != nil {
+		return err
+	}
+	for _, root := range resolvedRoots {
+		if pathWithin(resolved, root) {
+			return nil
+		}
+	}
+	return fmt.Errorf("symlink escapes allowed roots: %s", cleanPath)
+}

--- a/core/sandbox/local/symlink_guard_test.go
+++ b/core/sandbox/local/symlink_guard_test.go
@@ -1,0 +1,135 @@
+package local
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"goraven/core/sandbox/types"
+)
+
+func newTestWorkspace(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "documents"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "documents", "a.txt"), []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestCheckContainmentPlainPaths(t *testing.T) {
+	ws := newTestWorkspace(t)
+
+	if err := checkContainment(filepath.Join(ws, "documents"), []string{ws}); err != nil {
+		t.Errorf("inside path should pass: err=%v", err)
+	}
+	if err := checkContainment(filepath.Join(ws, "missing", "file.txt"), []string{ws}); err != nil {
+		t.Errorf("missing file inside workspace should pass, err=%v", err)
+	}
+	if err := checkContainment("/etc/passwd", []string{ws}); err == nil {
+		t.Errorf("outside path should fail")
+	}
+}
+
+func TestCheckContainmentSymlinkEscape(t *testing.T) {
+	ws := newTestWorkspace(t)
+
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("s"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// ws/link -> outside
+	if err := os.Symlink(outside, filepath.Join(ws, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	// 直接触及链接本身
+	if err := checkContainment(filepath.Join(ws, "link"), []string{ws}); err == nil {
+		t.Errorf("symlink escaping workspace should fail")
+	}
+	// 透过链接触及内部文件
+	if err := checkContainment(filepath.Join(ws, "link", "secret.txt"), []string{ws}); err == nil {
+		t.Errorf("file through escaping symlink should fail")
+	}
+}
+
+func TestCheckContainmentSymlinkInsideWorkspace(t *testing.T) {
+	ws := newTestWorkspace(t)
+	// documents -> docs（工作区内链接应当放行）
+	if err := os.Symlink(filepath.Join(ws, "documents"), filepath.Join(ws, "docs")); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkContainment(filepath.Join(ws, "docs", "a.txt"), []string{ws}); err != nil {
+		t.Errorf("internal symlink should pass, err=%v", err)
+	}
+}
+
+func TestSandboxValidateFilePathRejectsSymlinkEscape(t *testing.T) {
+	ws := newTestWorkspace(t)
+	sb := &LocalSandbox{userName: "u", Workspace: ws}
+
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(ws, "escape")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sb.validateFilePath(filepath.Join(ws, "escape")); err == nil {
+		t.Errorf("validateFilePath should reject escaping symlink")
+	}
+	if _, err := sb.validateFilePath(filepath.Join(ws, "documents")); err != nil {
+		t.Errorf("validateFilePath should accept normal path, err=%v", err)
+	}
+	// 尚不存在的文件（写入场景）也应放行
+	if _, err := sb.validateFilePath(filepath.Join(ws, "documents", "new", "b.txt")); err != nil {
+		t.Errorf("validateFilePath should accept missing file inside workspace, err=%v", err)
+	}
+}
+
+func TestFileManagerRejectsSymlinkEscape(t *testing.T) {
+	ws := newTestWorkspace(t)
+	fm := NewLocalFileManager(&types.FileManagerConfig{UserName: "u", Workspace: ws})
+
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("s"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(ws, "escape")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := fm.resolvePath("escape/secret.txt"); err == nil {
+		t.Errorf("resolvePath should reject file through escaping symlink")
+	}
+	if _, err := fm.resolvePath("documents/a.txt"); err != nil {
+		t.Errorf("resolvePath should accept normal relative path, err=%v", err)
+	}
+	if _, err := fm.resolvePath("../../../etc/passwd"); err == nil {
+		t.Errorf("resolvePath should reject traversal")
+	}
+}
+
+func TestGuardedBackendValidate(t *testing.T) {
+	ws := newTestWorkspace(t)
+	g := newGuardedBackend(nil, ws)
+
+	if got, err := g.validate(""); err != nil || got != ws {
+		t.Errorf("empty path should resolve to workspace, got %q err=%v", got, err)
+	}
+	if got, err := g.validate("documents/a.txt"); err != nil || got != filepath.Join(ws, "documents", "a.txt") {
+		t.Errorf("relative path should resolve inside workspace, got %q err=%v", got, err)
+	}
+	if _, err := g.validate("/etc/passwd"); err == nil {
+		t.Errorf("absolute outside path should fail")
+	}
+
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(ws, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := g.validate("escape/x.txt"); err == nil {
+		t.Errorf("symlink escape should fail")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.26.4
 	github.com/stretchr/testify v1.11.1
 	github.com/wk8/go-ordered-map/v2 v2.1.8
+	golang.org/x/crypto v0.52.0
 	google.golang.org/genai v1.36.0
 	gopkg.in/go-playground/validator.v9 v9.31.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -169,7 +170,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/arch v0.12.0 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa // indirect
 	golang.org/x/image v0.23.0 // indirect
 	golang.org/x/net v0.55.0 // indirect

--- a/util/password.go
+++ b/util/password.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"strings"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// HashPassword 生成 bcrypt 哈希，用于密码入库。
+func HashPassword(password string) (string, error) {
+	hashed, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hashed), nil
+}
+
+// VerifyPassword 校验明文密码与存储哈希是否匹配。
+//
+// 兼容历史版本的无盐 MD5 存储：存储值不是 bcrypt 时按 MD5 比对。
+// 返回 ok 表示密码是否正确，legacy 表示是否命中旧版 MD5（调用方可借此透明升级）。
+func VerifyPassword(storedHash, password string) (ok bool, legacy bool) {
+	if IsBcryptHash(storedHash) {
+		err := bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(password))
+		return err == nil, false
+	}
+	return storedHash == MD5(password), true
+}
+
+// IsBcryptHash 判断存储值是否为 bcrypt 哈希。
+func IsBcryptHash(stored string) bool {
+	// bcrypt 哈希以 $2 开头：$2a$、$2b$、$2y$ 等
+	return strings.HasPrefix(stored, "$2")
+}

--- a/util/password_test.go
+++ b/util/password_test.go
@@ -1,0 +1,46 @@
+package util
+
+import "testing"
+
+func TestHashAndVerifyPassword(t *testing.T) {
+	hashed, err := HashPassword("s3cret-pass")
+	if err != nil {
+		t.Fatalf("HashPassword failed: %v", err)
+	}
+	if !IsBcryptHash(hashed) {
+		t.Fatalf("HashPassword should produce a bcrypt hash, got %q", hashed)
+	}
+
+	ok, legacy := VerifyPassword(hashed, "s3cret-pass")
+	if !ok || legacy {
+		t.Errorf("VerifyPassword(bcrypt, correct) = %v, %v; want true, false", ok, legacy)
+	}
+	ok, _ = VerifyPassword(hashed, "wrong-pass")
+	if ok {
+		t.Errorf("VerifyPassword(bcrypt, wrong) should fail")
+	}
+}
+
+func TestVerifyPasswordLegacyMD5(t *testing.T) {
+	// 旧版无盐 MD5 存储兼容
+	legacyHash := MD5("legacy-pass")
+
+	ok, legacy := VerifyPassword(legacyHash, "legacy-pass")
+	if !ok || !legacy {
+		t.Errorf("VerifyPassword(md5, correct) = %v, %v; want true, true", ok, legacy)
+	}
+	ok, _ = VerifyPassword(legacyHash, "wrong-pass")
+	if ok {
+		t.Errorf("VerifyPassword(md5, wrong) should fail")
+	}
+}
+
+func TestIsBcryptHash(t *testing.T) {
+	if IsBcryptHash(MD5("x")) {
+		t.Errorf("MD5 hash must not be detected as bcrypt")
+	}
+	if IsBcryptHash("$2a$10$invalidbutprefix") != true {
+		// 前缀判断，宽松识别
+		t.Log("prefix detection")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #10 with two more fixes from the same security review.

### 1. Migrate password storage from unsalted MD5 to bcrypt

Passwords were stored as plain unsalted MD5 hashes. This adds `util.HashPassword` / `util.VerifyPassword` (bcrypt) and switches every write path (install, admin create/reset, change password) to bcrypt. Login transparently accepts legacy MD5 hashes and **upgrades them to bcrypt on first successful login**, so existing installs keep working without any manual migration.

Verified live: install → login upgrades stored hash from `md5...` to `$2a$...`, second login goes through bcrypt, change-password and old-password rejection still work.

### 2. Add symlink containment to the local sandbox

The local sandbox validated paths with plain string-prefix checks, so a symlink created inside the workspace (e.g. `ln -s / workspace/link`) escaped validation:

- `LocalSandbox.validateFilePath` and `LocalFileManager.resolvePath` now resolve symlinks (including on the deepest existing ancestor for not-yet-written files) and require the resolved path to stay within the workspace. Symlinks pointing *within* the workspace remain allowed.
- The agent file tools (read/write/edit/grep/glob/ls) are backed by eino-ext's local backend, which has **no root constraint at all** (default root `/`). `NewBackend` now wraps it in a `guardedBackend` decorator that constrains every operation to the user workspace and resolves relative paths against it, instead of the process CWD.
- `/api/hfs/file/{p}` (absolute download) additionally validates the symlink-resolved path, and tolerates a relative `user_space` config by resolving it to an absolute path first.

Verified live: downloading a regular workspace file returns 200, downloading through a `escape -> /etc` symlink returns 403, path traversal via the file manager is still rejected.

## Testing

- [x] `go build ./...` and `go vet` clean (pre-existing vet warning in `clawhub_test.go` untouched)
- [x] New unit tests: bcrypt hash/verify + legacy MD5 compatibility, symlink containment (plain/escape/internal-link/missing-file cases), file-manager traversal, guarded-backend path validation
- [x] Full suite: failing-test set identical to master (26 pre-existing, environment-dependent failures — diffed, no new failures)
- [x] Deployed the rebuilt binary in the Docker runtime and verified the flows listed above end-to-end

## Notes

- `golang.org/x/crypto` moves from indirect to direct dependency (no version change).
- The `docker` sandbox backend (currently a stub) remains the proper long-term isolation boundary; these checks harden the local backend in the meantime.

—
🤖 Generated with [opencode](https://opencode.ai)