### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/backend/repository/seed/mcp_endpoints.go
+++ b/backend/repository/seed/mcp_endpoints.go
@@ -86,4 +86,15 @@ var RecommendMCPEndpoints = []po.MCPEndpoint{
 		Status:      po.MCPEndpointStatusEnabled,
 		Remark:      "Please register an API key at Aliyun Bailian (https://bailian.console.aliyun.com/) and set it as DASHSCOPE_API_KEY.",
 	},
+	{
+		Name:        "youcom-search",
+		DisplayName: "You.com Search",
+		Icon:        "globe",
+		Description: "You.com hosted MCP server for current web search, URL content extraction, and cited web research. Exposes the you-search, you-contents, and you-research tools, so agents can pull live web information with sources instead of relying on stale training data.",
+		Transport:   "StreamableHttp",
+		HttpUrl:     "https://api.you.com/mcp",
+		HttpHeader:  `{"Authorization":"Bearer ${YDC_API_KEY}"}`,
+		Status:      po.MCPEndpointStatusEnabled,
+		Remark:      "Get an API key at https://you.com/platform/api-keys and set it as YDC_API_KEY. A keyless entry point with basic search only is also available at https://api.you.com/mcp?profile=free.",
+	},
 }


### PR DESCRIPTION
GoRaven ships a set of recommended MCP endpoints (`backend/repository/seed/mcp_endpoints.go`) that admins can add from the MCP setup UI. I noticed the list already covers web search/scraping (Brave Search, Firecrawl, Aliyun WebSearch) but has no hosted web-search option, so I added the You.com MCP server as a `StreamableHttp` entry following the same shape as the Aliyun entries.

## What changed

One new entry in `RecommendMCPEndpoints`:

- Name: `youcom-search`, transport `StreamableHttp`
- URL: `https://api.you.com/mcp`
- Header: `{"Authorization":"Bearer ${YDC_API_KEY}"}` (same `${ENV_VAR}` interpolation pattern as the Aliyun entries)
- Remark points to https://you.com/platform/api-keys for the key, and notes a keyless basic-search profile (`https://api.you.com/mcp?profile=free`) for users who just want search without an account

The endpoint exposes `you-search`, `you-contents`, and `you-research` tools, so agents can pull live web results with citations, read URLs, and do multi-source research instead of relying on training data.

It's purely additive seed data — nothing changes for existing users unless an admin explicitly adds the endpoint and sets `YDC_API_KEY`.

## Validation

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./backend/repository/...` and `./backend/controller/test/` fail identically before and after this change — they are integration tests that expect a live server on `localhost:8000` and a configured DB file, so they can't run in a clean checkout (verified by stashing the diff and re-running).

Happy to adjust the entry (name, icon, description) or drop it into a different seed grouping if you'd prefer.